### PR TITLE
Change GameStatus.Flags to an Enum

### DIFF
--- a/EliteAPI/EliteAPI.csproj
+++ b/EliteAPI/EliteAPI.csproj
@@ -362,6 +362,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Inara\InaraConnection.cs" />
     <Compile Include="Status\CargoWatcher.cs" />
+    <Compile Include="Status\ShipStatusFlags.cs" />
     <Compile Include="Status\StatusWatcher.cs" />
     <Compile Include="ThirdParty\ThirdPartyWrapper.cs" />
     <None Include="NuGet.Config" />

--- a/EliteAPI/Status/GameStatus.cs
+++ b/EliteAPI/Status/GameStatus.cs
@@ -18,7 +18,7 @@
         public string Event { get; internal set; }
 
         [JsonProperty("Flags")]
-        public long Flags { get; internal set; }
+        public ShipStatusFlags Flags { get; internal set; }
 
         [JsonProperty("Pips")]
         public List<long> Pips { get; internal set; }
@@ -35,34 +35,63 @@
         [JsonProperty("Cargo")]
         public long Cargo { get; internal set; }
 
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool Docked { get { return GetFlag(0); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool Landed { get { return GetFlag(1); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool Gear { get { return GetFlag(2); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool Shields { get { return GetFlag(3); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool Supercruise { get { return GetFlag(4); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool FlightAssist { get { return !GetFlag(5); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool Hardpoints { get { return GetFlag(6); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool Winging { get { return GetFlag(7); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool Lights { get { return GetFlag(8); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool CargoScoop { get { return GetFlag(9); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool SilentRunning { get { return GetFlag(10); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool Scooping { get { return GetFlag(11); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool SrvHandbreak { get { return GetFlag(12); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool SrvTurrent { get { return GetFlag(13); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool SrvNearShip { get { return GetFlag(14); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool SrvDriveAssist { get { return GetFlag(15); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool MassLocked { get { return GetFlag(16); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool FsdCharging { get { return GetFlag(17); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool FsdCooldown { get { return GetFlag(18); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool LowFuel { get { return GetFlag(19); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool Overheating { get { return GetFlag(20); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool HasLatlong { get { return GetFlag(21); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool InDanger { get { return GetFlag(22); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool InInterdiction { get { return GetFlag(23); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool InMothership { get { return GetFlag(24); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool InFighter { get { return GetFlag(25); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool InSRV { get { return GetFlag(26); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool AnalysisMode { get { return GetFlag(27); } }
+        [Obsolete("Use Flags.HasFlag() instead")]
         public bool NightVision { get { return GetFlag(28); } }
 
         public string GameMode { get; internal set; }
@@ -72,11 +101,10 @@
         public bool InMainMenu { get; internal set; }
         public string MusicTrack { get; internal set; }
 
-        public bool GetFlag(long bit)
+        [Obsolete("Use Flags.HasFlag() instead")]
+        public bool GetFlag(int bit)
         {
-            char[] carray = Convert.ToString(Flags, 2).ToCharArray();
-            Array.Reverse(carray);
-            try { return Equals(carray[bit], '1'); } catch { return false; }
+            return Flags.HasFlag((ShipStatusFlags)(1 << bit));
         }
     }
 

--- a/EliteAPI/Status/ShipStatusFlags.cs
+++ b/EliteAPI/Status/ShipStatusFlags.cs
@@ -1,0 +1,39 @@
+﻿namespace EliteAPI.Status
+{
+    using System;
+
+    [Flags]
+    public enum ShipStatusFlags
+    {
+        None = 0,
+        Docked = 1,
+        Landed = 1 << 1,
+        Gear = 1 << 2,
+        Shields = 1 << 3,
+        Supercruise = 1 << 4,
+        FlightAssistOff = 1 << 5,
+        Hardpoints = 1 << 6,
+        Winging = 1 << 7,
+        Lights = 1 << 8,
+        CargoScoop = 1 << 9,
+        SilentRunning = 1 << 10,
+        Scooping = 1 << 11,
+        SrvHandbreak = 1 << 12,
+        SrvTurret = 1 << 13,
+        SrvNearShip = 1 << 14,
+        SrvDriveAssist = 1 << 15,
+        MassLocked = 1 << 16,
+        FsdCharging = 1 << 17,
+        FsdCooldown = 1 << 18,
+        LowFuel = 1 << 19,
+        Overheating = 1 << 20,
+        HasLatlong = 1 << 21,
+        InDanger = 1 << 22,
+        InInterdiction = 1 << 23,
+        InMothership = 1 << 24,
+        InFighter = 1 << 25,
+        InSrv = 1 << 26,
+        AnalysisMode = 1 << 27,
+        NightVision = 1 << 28,
+    }
+}


### PR DESCRIPTION
`GameStatus.GetFlag()` and all properties that depend on it are very unperformant, as each invocation requires a conversion to `string`, then to a `char` array, then a `reverse` array operation.

The same results can be achieved by letting .NET treat the `Flags` property as a flags Enum. Less code, and easier to maintain.