### PR TITLE
Pass the parsed event to AllEvent event handler

### DIFF
--- a/EliteAPI/JournalParser.cs
+++ b/EliteAPI/JournalParser.cs
@@ -96,6 +96,7 @@ namespace EliteAPI
                         if (eventMethod != null)
                         {
                             var parsedEvent = eventMethod.Invoke(null, new object[] {json, EliteAPI});
+                            obj = parsedEvent;
                         }
 
                         //amountOfProcessedFields = parsedEvent.GetType().GetProperties().Length;

--- a/EliteAPI/JournalParser.cs
+++ b/EliteAPI/JournalParser.cs
@@ -95,8 +95,7 @@ namespace EliteAPI
                     {
                         if (eventMethod != null)
                         {
-                            var parsedEvent = eventMethod.Invoke(null, new object[] {json, EliteAPI});
-                            obj = parsedEvent;
+                            obj = eventMethod.Invoke(null, new object[] {json, EliteAPI});
                         }
 
                         //amountOfProcessedFields = parsedEvent.GetType().GetProperties().Length;


### PR DESCRIPTION
Passes the successfully parsed Event to the AllEvent handler, instead of the Newtonsoft JObject.