### PR TITLE
Adds compatibility to compile and run with Dotnet Core

### DIFF
--- a/EliteAPI/Discord/RichPresenceClient.cs
+++ b/EliteAPI/Discord/RichPresenceClient.cs
@@ -89,7 +89,7 @@ namespace EliteAPI.Discord
         public RichPresenceClient TurnOn(bool automatic = true)
         {
             //Create RPC client.
-            rpc = new DiscordRpcClient(clientID, true);
+            rpc = new DiscordRpcClient(clientID, autoEvents: true);
             Logger.Log("Starting rich presence.");
 
             //Subscribe to events.
@@ -253,7 +253,8 @@ namespace EliteAPI.Discord
             //Remove all presences from queue, and clear it.
             try
             {
-                rpc.DequeueAll();
+                // Unsure if DequeueAll is still a requirement at this point
+                //rpc.DequeueAll();
                 rpc.ClearPresence();
             }
             catch (Exception ex) { Logger.Log(Severity.Error, "Could not terminate rich presence.", ex); }

--- a/EliteAPI/EliteAPI.csproj
+++ b/EliteAPI/EliteAPI.csproj
@@ -17,6 +17,7 @@ VoiceAttack, VoiceMacro, Discord, C#, VB</Description>
     <Version>2.3.1.0-alpha3</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageIcon>logo_gradient_small.jpg</PackageIcon>
+    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -61,8 +62,12 @@ VoiceAttack, VoiceMacro, Discord, C#, VB</Description>
     </None>
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(IsWindows)'=='true'">
     <Exec Command="copy &quot;$(SolutionDir)lib\vmAPI.dll&quot; &quot;$(TargetDir)vmAPI.dll&quot;&#xD;&#xA;" />
+  </Target>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(IsWindows)'=='true'">
+    <Exec Command="cp &quot;$(SolutionDir)lib/vmAPI.dll&quot; &quot;$(TargetDir)vmAPI.dll&quot;&#xD;&#xA;" />
   </Target>
 
 </Project>

--- a/EliteAPI/EliteAPI.csproj
+++ b/EliteAPI/EliteAPI.csproj
@@ -64,7 +64,7 @@ VoiceAttack, VoiceMacro, Discord, C#, VB</Description>
     <Exec Command="copy &quot;$(SolutionDir)lib\vmAPI.dll&quot; &quot;$(TargetDir)vmAPI.dll&quot;&#xD;&#xA;" />
   </Target>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(IsWindows)'=='true'">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(IsWindows)'=='false'">
     <Exec Command="cp &quot;$(SolutionDir)lib/vmAPI.dll&quot; &quot;$(TargetDir)vmAPI.dll&quot;&#xD;&#xA;" />
   </Target>
 

--- a/EliteAPI/EliteAPI.csproj
+++ b/EliteAPI/EliteAPI.csproj
@@ -27,6 +27,7 @@ VoiceAttack, VoiceMacro, Discord, C#, VB</Description>
 
   <ItemGroup>
     <PackageReference Include="Costura.Fody" Version="4.1.0" />
+    <PackageReference Include="DiscordRichPresence" Version="1.143.0" />
     <PackageReference Include="Fody" Version="6.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -44,9 +45,6 @@ VoiceAttack, VoiceMacro, Discord, C#, VB</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="DiscordRPC">
-      <HintPath>..\lib\DiscordRPC.dll</HintPath>
-    </Reference>
     <Reference Include="Somfic">
       <HintPath>..\..\Somfic\Somfic\bin\Debug\netstandard2.0\Somfic.dll</HintPath>
     </Reference>

--- a/EliteAPI/EliteDangerousAPI.cs
+++ b/EliteAPI/EliteDangerousAPI.cs
@@ -46,7 +46,7 @@ namespace EliteAPI
                 int result = UnsafeNativeMethods.SHGetKnownFolderPath(new Guid("4C5C32FF-BB9D-43B0-B5B4-2D72E54EAAA4"), 0, new IntPtr(0), out IntPtr path);
                 if (result >= 0)
                 {
-                    try { return new DirectoryInfo(Marshal.PtrToStringUni(path) + $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}/Saved Games/Frontier Developments/Elite Dangerous"); }
+                    try { return new DirectoryInfo(Marshal.PtrToStringUni(path) + "/Frontier Developments/Elite Dangerous"); }
                     catch { return new DirectoryInfo(Directory.GetCurrentDirectory()); }
                 }
                 else

--- a/EliteAPI/EliteDangerousAPI.cs
+++ b/EliteAPI/EliteDangerousAPI.cs
@@ -40,10 +40,13 @@ namespace EliteAPI
         {
             get
             {
+                // Don't try to find the special folder if not on Windows
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return new DirectoryInfo(Directory.GetCurrentDirectory());
+
                 int result = UnsafeNativeMethods.SHGetKnownFolderPath(new Guid("4C5C32FF-BB9D-43B0-B5B4-2D72E54EAAA4"), 0, new IntPtr(0), out IntPtr path);
                 if (result >= 0)
                 {
-                    try { return new DirectoryInfo(Marshal.PtrToStringUni(path) + @"\Frontier Developments\Elite Dangerous"); }
+                    try { return new DirectoryInfo(Marshal.PtrToStringUni(path) + $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}/Saved Games/Frontier Developments/Elite Dangerous"); }
                     catch { return new DirectoryInfo(Directory.GetCurrentDirectory()); }
                 }
                 else

--- a/EliteAPI/EliteDangerousAPI.cs
+++ b/EliteAPI/EliteDangerousAPI.cs
@@ -91,7 +91,7 @@ namespace EliteAPI
         /// <summary>
         /// Returns all the modules installed on the current ship.
         /// </summary>
-        public ShipModules Modules => ShipModules.FromFile(new FileInfo(JournalDirectory.FullName + "\\ModulesInfo.json"), this);
+        public ShipModules Modules => ShipModules.FromFile(new FileInfo(Path.Combine(JournalDirectory.FullName, "ModulesInfo.json")), this);
 
         /// <summary>
         /// Holds information on all key bindings in the game set by the user.
@@ -373,7 +373,7 @@ namespace EliteAPI
             }
             else
             {
-                Logger.Log(Severity.Error, "Could not find Status.json.", new FileNotFoundException("This error usually occurs when Elite: Dangerous hasn't been run on this machine yet.", $"{JournalDirectory.FullName}\\Status.json"));
+                Logger.Log(Severity.Error, "Could not find Status.json.", new FileNotFoundException("This error usually occurs when Elite: Dangerous hasn't been run on this machine yet.", $"{Path.Combine(JournalDirectory.FullName, "Status.json")}"));
                 Logger.Log("Live updates, such as the landing gear & hardpoints, are not supported without access to 'Status.json'. The Status file is only created after the first run of Elite: Dangerous. If this is not the first time you're running Elite: Dangerous on this machine, change the journal directory.");
                 Logger.Log(Severity.Warning, "A critical part of EliteAPI will be offline.", new Exception("PROCEEDING WITH LIMITED FUNCTIONALITY"));
                 Logger.Log("Proceeding in 20 seconds ...");


### PR DESCRIPTION
Tested on Arch with dotnet core 3.1.3

```
.NET Core SDK (reflecting any global.json):
 Version:   3.1.103
 Commit:    6f74c4a1dd

Runtime Environment:
 OS Name:     arch
 OS Version:  
 OS Platform: Linux
 RID:         arch-x64
 Base Path:   /usr/share/dotnet/sdk/3.1.103/

Host (useful for support):
  Version: 3.1.3
  Commit:  ed88943d24

.NET Core SDKs installed:
  3.1.103 [/usr/share/dotnet/sdk]

.NET Core runtimes installed:
  Microsoft.NETCore.App 3.1.3 [/usr/share/dotnet/shared/Microsoft.NETCore.App]
```

Replaced external Discord RPC library with the following NuGet package: 
https://github.com/Lachee/discord-rpc-csharp

Initial testing seems promising and had no issues in both Windows and Linux. The replacement was necessary as the old library would try to access the Windows registry classes, which are not available on other platforms.
