### PR TITLE
Adds OnReset event

### DIFF
--- a/EliteAPI/EliteAPI.xml
+++ b/EliteAPI/EliteAPI.xml
@@ -302,6 +302,11 @@
             Gets triggered when EliteAPI is closing.
             </summary>
         </member>
+        <member name="E:EliteAPI.EliteDangerousAPI.OnReset">
+            <summary>
+            Gets triggered when EliteAPI has been reset.
+            </summary>
+        </member>
         <member name="E:EliteAPI.EliteDangerousAPI.OnError">
             <summary>
             Gets triggered when EliteAPI could not successfully load up.

--- a/EliteAPI/EliteDangerousAPI.cs
+++ b/EliteAPI/EliteDangerousAPI.cs
@@ -247,6 +247,8 @@ namespace EliteAPI
             try { Status = EliteAPI.Status.GameStatus.FromFile(new FileInfo(JournalDirectory + "//Status.json"), this); } catch (Exception ex) { Logger.Log(Severity.Warning, "Couldn't instantiate service 'Status'.", ex); }
             try { JournalParser = new JournalParser(this); } catch (Exception ex) { Logger.Log(Severity.Warning, "Couldn't instantiate service 'JournalParser'.", ex); } 
             JournalParser.processedLogs = new List<string>();
+
+            OnReset?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>
@@ -480,6 +482,11 @@ namespace EliteAPI
         /// Gets triggered when EliteAPI is closing.
         /// </summary>
         public event EventHandler OnQuit;
+
+        /// <summary>
+        /// Gets triggered when EliteAPI has been reset.
+        /// </summary>
+        public event EventHandler OnReset;
 
         /// <summary>
         /// Gets triggered when EliteAPI could not successfully load up.


### PR DESCRIPTION
So new event handlers can be added before Start loop. This allows all events that are parsed on load to be passed on.

```
            EliteAPI = new EliteDangerousAPI();

            EliteAPI.OnReset += (s, e) => {
                EliteAPI.Events.CommanderEvent += HandleCommanderInfo;
                EliteAPI.Events.AllEvent += HandleEvent;
            };

            EliteAPI.Start();
```