### PR TITLE
Support processing historical journals

### DIFF
--- a/EliteAPI/Configuration/Abstractions/IEliteDangerousApiConfiguration.cs
+++ b/EliteAPI/Configuration/Abstractions/IEliteDangerousApiConfiguration.cs
@@ -38,8 +38,8 @@ namespace EliteAPI.Configuration.Abstractions
         bool ProcessHistoricalJournals { get; set; }
 
         /// <summary>
-        /// The number of days in the past EliteAPI will process for historical journal files
+        /// The timespan in the past EliteAPI will process for historical journal files
         /// </summary>
-        int? HistoricalJournalDays { get; set; }
+        TimeSpan HistoricalJournalSpan { get; set; }
     }
 }

--- a/EliteAPI/Configuration/Abstractions/IEliteDangerousApiConfiguration.cs
+++ b/EliteAPI/Configuration/Abstractions/IEliteDangerousApiConfiguration.cs
@@ -31,5 +31,15 @@ namespace EliteAPI.Configuration.Abstractions
         /// The active bindings file
         /// </summary>
         string BindingsFile { get; set; }
+
+        /// <summary>
+        /// Determines if EliteAPI will process historical journal files
+        /// </summary>
+        bool ProcessHistoricalJournals { get; set; }
+
+        /// <summary>
+        /// The number of days in the past EliteAPI will process for historical journal files
+        /// </summary>
+        int? HistoricalJournalDays { get; set; }
     }
 }

--- a/EliteAPI/Configuration/EliteDangerousAPIConfigurationBuilder.cs
+++ b/EliteAPI/Configuration/EliteDangerousAPIConfigurationBuilder.cs
@@ -23,7 +23,7 @@ namespace EliteAPI.Configuration
         private string _options;
         private TimeSpan _tickFrequency;
         private bool _processHistoricalJournals;
-        private int? _historicalJournalDays;
+        private TimeSpan _historicalJournalSpan;
 
         internal EliteDangerousApiConfigurationBuilder()
         {
@@ -81,10 +81,19 @@ namespace EliteAPI.Configuration
         /// <summary>
         /// Enables the processing of historical journal files with an option number of days to process
         /// </summary>
-        public void UseHistoricalJournals(int? numberOfDays = null)
+        public void UseHistoricalJournals(int numberOfDays)
         {
             _processHistoricalJournals = true;
-            _historicalJournalDays = numberOfDays;
+            _historicalJournalSpan = TimeSpan.FromDays(numberOfDays);
+        }
+        
+        /// <summary>
+        /// Enables the processing of historical journal files with an option number of days to process
+        /// </summary>
+        public void UseHistoricalJournals(TimeSpan timeSpan)
+        {
+            _processHistoricalJournals = true;
+            _historicalJournalSpan = timeSpan;
         }
 
         /// <summary>
@@ -136,7 +145,7 @@ namespace EliteAPI.Configuration
                 BindingsFile = _bindings, 
                 TickFrequency = _tickFrequency,
                 ProcessHistoricalJournals = _processHistoricalJournals,
-                HistoricalJournalDays = _historicalJournalDays
+                HistoricalJournalSpan = _historicalJournalSpan
             };
         }
     }

--- a/EliteAPI/Configuration/EliteDangerousAPIConfigurationBuilder.cs
+++ b/EliteAPI/Configuration/EliteDangerousAPIConfigurationBuilder.cs
@@ -22,6 +22,8 @@ namespace EliteAPI.Configuration
         private string _journalDirectory;
         private string _options;
         private TimeSpan _tickFrequency;
+        private bool _processHistoricalJournals;
+        private int? _historicalJournalDays;
 
         internal EliteDangerousApiConfigurationBuilder()
         {
@@ -75,7 +77,16 @@ namespace EliteAPI.Configuration
         {
             _journal = file;
         }
-        
+
+        /// <summary>
+        /// Enables the processing of historical journal files with an option number of days to process
+        /// </summary>
+        public void UseHistoricalJournals(int? numberOfDays = null)
+        {
+            _processHistoricalJournals = true;
+            _historicalJournalDays = numberOfDays;
+        }
+
         /// <summary>
         /// Sets which bindings to use
         /// </summary>
@@ -117,7 +128,16 @@ namespace EliteAPI.Configuration
 
         private EliteDangerousApiConfiguration Build()
         {
-            return new() {JournalPath = _journalDirectory, JournalFile = _journal, OptionsPath = _options, BindingsFile = _bindings, TickFrequency = _tickFrequency};
+            return new()
+            {
+                JournalPath = _journalDirectory, 
+                JournalFile = _journal, 
+                OptionsPath = _options, 
+                BindingsFile = _bindings, 
+                TickFrequency = _tickFrequency,
+                ProcessHistoricalJournals = _processHistoricalJournals,
+                HistoricalJournalDays = _historicalJournalDays
+            };
         }
     }
 }

--- a/EliteAPI/Configuration/EliteDangerousApiConfiguration.cs
+++ b/EliteAPI/Configuration/EliteDangerousApiConfiguration.cs
@@ -25,5 +25,11 @@ namespace EliteAPI.Configuration
 
         /// <inheritdoc />
         public string BindingsFile { get; set; }
+
+        /// <inheritdoc />
+        public bool ProcessHistoricalJournals { get; set; }
+
+        /// <inheritdoc />
+        public int? HistoricalJournalDays { get; set; }
     }
 }

--- a/EliteAPI/Configuration/EliteDangerousApiConfiguration.cs
+++ b/EliteAPI/Configuration/EliteDangerousApiConfiguration.cs
@@ -30,6 +30,6 @@ namespace EliteAPI.Configuration
         public bool ProcessHistoricalJournals { get; set; }
 
         /// <inheritdoc />
-        public int? HistoricalJournalDays { get; set; }
+        public TimeSpan HistoricalJournalSpan { get; set; }
     }
 }

--- a/EliteAPI/EliteAPI.xml
+++ b/EliteAPI/EliteAPI.xml
@@ -149,6 +149,16 @@
             The active bindings file
             </summary>
         </member>
+        <member name="P:EliteAPI.Configuration.Abstractions.IEliteDangerousApiConfiguration.ProcessHistoricalJournals">
+            <summary>
+            Determines if EliteAPI will process historical journal files
+            </summary>
+        </member>
+        <member name="P:EliteAPI.Configuration.Abstractions.IEliteDangerousApiConfiguration.HistoricalJournalDays">
+            <summary>
+            The number of days in the past EliteAPI will process for historical journal files
+            </summary>
+        </member>
         <member name="T:EliteAPI.Configuration.EliteDangerousApiConfiguration">
             <summary>
             Standard implementation of the <see cref="T:EliteAPI.Configuration.Abstractions.IEliteDangerousApiConfiguration" /> configuration class
@@ -167,6 +177,12 @@
             <inheritdoc />
         </member>
         <member name="P:EliteAPI.Configuration.EliteDangerousApiConfiguration.BindingsFile">
+            <inheritdoc />
+        </member>
+        <member name="P:EliteAPI.Configuration.EliteDangerousApiConfiguration.ProcessHistoricalJournals">
+            <inheritdoc />
+        </member>
+        <member name="P:EliteAPI.Configuration.EliteDangerousApiConfiguration.HistoricalJournalDays">
             <inheritdoc />
         </member>
         <member name="T:EliteAPI.Configuration.EliteDangerousApiConfigurationBuilder">
@@ -199,6 +215,11 @@
         <member name="M:EliteAPI.Configuration.EliteDangerousApiConfigurationBuilder.UseJournalFile(System.String)">
             <summary>
             Sets which journal file to use, defaults to latest if not invoked
+            </summary>
+        </member>
+        <member name="M:EliteAPI.Configuration.EliteDangerousApiConfigurationBuilder.UseHistoricalJournals(System.Nullable{System.Int32})">
+            <summary>
+            Enables the processing of historical journal files with an option number of days to process
             </summary>
         </member>
         <member name="M:EliteAPI.Configuration.EliteDangerousApiConfigurationBuilder.UseBindingsFile(System.String)">
@@ -969,10 +990,19 @@
             </summary>
             <param name="journalDirectory"> The journal directory </param>
         </member>
+        <member name="M:EliteAPI.Journal.Provider.Abstractions.IJournalProvider.FindJournalFiles(System.IO.DirectoryInfo)">
+            <summary>
+            Finds the journal files from the specified journal directory
+            </summary>
+            <param name="journalDirectory"> The journal directory </param>
+        </member>
         <member name="T:EliteAPI.Journal.Provider.JournalProvider">
             <inheritdoc />
         </member>
         <member name="M:EliteAPI.Journal.Provider.JournalProvider.FindJournalFile(System.IO.DirectoryInfo)">
+            <inheritdoc />
+        </member>
+        <member name="M:EliteAPI.Journal.Provider.JournalProvider.FindJournalFiles(System.IO.DirectoryInfo)">
             <inheritdoc />
         </member>
         <member name="M:EliteAPI.JsonContractResolver.CreateProperties(System.Type,Newtonsoft.Json.MemberSerialization)">
@@ -986,6 +1016,11 @@
         <member name="E:EliteAPI.Options.Abstractions.IOption.OnChange">
             <summary>
             Triggered when any of the properties of this option have been updated
+            </summary>
+        </member>
+        <member name="M:EliteAPI.Options.Abstractions.IOption.ToJson">
+            <summary>
+            This option's JSON
             </summary>
         </member>
         <member name="T:EliteAPI.Options.Bindings.Models.IBindings">
@@ -1005,6 +1040,9 @@
             <inheritdoc />
         </member>
         <member name="M:EliteAPI.Options.Bindings.Bindings.EliteAPI#Options#Abstractions#IOption#TriggerOnChange">
+            <inheritdoc />
+        </member>
+        <member name="M:EliteAPI.Options.Bindings.Bindings.ToJson">
             <inheritdoc />
         </member>
         <member name="P:EliteAPI.Options.Bindings.Bindings.EliteAPI#Options#Bindings#Models#IBindings#Active">

--- a/EliteAPI/EliteDangerousApi.cs
+++ b/EliteAPI/EliteDangerousApi.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-
 using EliteAPI.Abstractions;
 using EliteAPI.Configuration.Abstractions;
 using EliteAPI.Event.Processor.Abstractions;
@@ -32,13 +31,14 @@ using EliteAPI.Status.Shipyard.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-
 using EventHandler = EliteAPI.Event.Handler.EventHandler;
 
 namespace EliteAPI
 {
     [Obsolete("Use EliteDangerousApi instead", true)]
-    public class EliteDangerousAPI { }
+    public class EliteDangerousAPI
+    {
+    }
 
     /// <inheritdoc />
     public class EliteDangerousApi : IEliteDangerousApi
@@ -84,7 +84,8 @@ namespace EliteAPI
                 Outfitting = services.GetRequiredService<IOutfitting>();
                 Bindings = services.GetRequiredService<IBindings>();
 
-                Version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0];
+                Version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    .InformationalVersion.Split('+')[0];
 
                 _config = services.GetRequiredService<IConfiguration>();
                 _codeConfig = services.GetRequiredService<IEliteDangerousApiConfiguration>();
@@ -104,7 +105,10 @@ namespace EliteAPI
                 _optionsProvider = services.GetRequiredService<IOptionsProvider>();
                 _optionsProcessor = services.GetRequiredService<IOptionsProcessor>();
             }
-            catch (Exception ex) { PreInitializationException = ex; }
+            catch (Exception ex)
+            {
+                PreInitializationException = ex;
+            }
         }
 
         private DirectoryInfo JournalDirectory { get; set; }
@@ -140,13 +144,13 @@ namespace EliteAPI
 
         /// <inheritdoc />
         public IShip Ship { get; }
-        
+
         /// <inheritdoc />
         public ICommander Commander { get; }
 
         /// <inheritdoc />
         public IBackpack Backpack { get; }
-        
+
         /// <inheritdoc />
         public IShipyard Shipyard { get; }
 
@@ -164,7 +168,7 @@ namespace EliteAPI
 
         /// <inheritdoc />
         public IOutfitting Outfitting { get; }
-        
+
         /// <inheritdoc />
         public IBindings Bindings { get; }
 
@@ -229,7 +233,7 @@ namespace EliteAPI
                 OnStart?.Invoke(this, EventArgs.Empty);
 
                 if (_codeConfig.ProcessHistoricalJournals)
-                    await ProcessHistoricalJournalFiles(_codeConfig.HistoricalJournalDays);
+                    await ProcessHistoricalJournalFiles(_codeConfig.HistoricalJournalSpan);
 
                 while (IsRunning)
                 {
@@ -240,7 +244,7 @@ namespace EliteAPI
                 OnStop?.Invoke(this, EventArgs.Empty);
             });
         }
-        
+
         /// <inheritdoc />
         public Task StopAsync()
         {
@@ -278,7 +282,7 @@ namespace EliteAPI
                 await _statusProcessor.ProcessBackpackFile(BackpackFile);
                 await _statusProcessor.ProcessNavRouteFile(NavRouteFile);
                 await _statusProcessor.ProcessModulesFile(ModulesInfoFile);
-                
+
                 await _optionsProcessor.ProcessBindingsFile(BindingsFile);
 
                 await SetJournalFile();
@@ -291,14 +295,20 @@ namespace EliteAPI
                     HasCatchedUp = true;
                 }
             }
-            catch (Exception ex) { _log.LogWarning(ex, "Could not do tick"); }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "Could not do tick");
+            }
         }
 
         private async Task InitializeEventHandlers()
         {
             _log.LogTrace("Initializing event handlers");
             foreach (var eventProcessor in _eventProcessors)
-                try { await eventProcessor.RegisterHandlers(); }
+                try
+                {
+                    await eventProcessor.RegisterHandlers();
+                }
                 catch (Exception ex)
                 {
                     _log.LogWarning(ex, "Could not initialize event handler {name}", eventProcessor.GetType().FullName);
@@ -311,9 +321,13 @@ namespace EliteAPI
             try
             {
                 var eventBase = await _eventProvider.ProcessJsonEvent(e.Json);
-                foreach (var eventProcessor in _eventProcessors) await eventProcessor.InvokeHandler(eventBase, e.IsWhileCatchingUp);
+                foreach (var eventProcessor in _eventProcessors)
+                    await eventProcessor.InvokeHandler(eventBase, e.IsWhileCatchingUp);
             }
-            catch (Exception ex) { _log.LogWarning(ex, "Could not execute event"); }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "Could not execute event");
+            }
         }
 
         private async Task SetJournalDirectory()
@@ -332,7 +346,7 @@ namespace EliteAPI
                 throw;
             }
         }
-        
+
         private async Task SetOptionsDirectory()
         {
             try
@@ -361,7 +375,10 @@ namespace EliteAPI
                 _log.LogInformation("Setting journal file to {filePath}", newJournalFile.Name);
 
                 if (!newJournalFile.Name.Contains("Journal"))
-                    _log.LogWarning(new InvalidJournalFileException($"The selected journal file '{newJournalFile.Name}' does not match standard naming conventions"), "Invalid journal file detected, errors may occur");
+                    _log.LogWarning(
+                        new InvalidJournalFileException(
+                            $"The selected journal file '{newJournalFile.Name}' does not match standard naming conventions"),
+                        "Invalid journal file detected, errors may occur");
 
                 JournalFile = newJournalFile;
             }
@@ -373,25 +390,34 @@ namespace EliteAPI
         }
 
         private string lastPresetErrorname = "";
+
         private async Task SetSupportFiles()
         {
             try
             {
-                if (!DisabledSupportFiles.Contains("Status")) StatusFile = await _statusProvider.FindStatusFile(JournalDirectory);
+                if (!DisabledSupportFiles.Contains("Status"))
+                    StatusFile = await _statusProvider.FindStatusFile(JournalDirectory);
 
-                if (!DisabledSupportFiles.Contains("Cargo")) CargoFile = await _statusProvider.FindCargoFile(JournalDirectory);
+                if (!DisabledSupportFiles.Contains("Cargo"))
+                    CargoFile = await _statusProvider.FindCargoFile(JournalDirectory);
 
-                if (!DisabledSupportFiles.Contains("Market")) MarketFile = await _statusProvider.FindMarketFile(JournalDirectory);
+                if (!DisabledSupportFiles.Contains("Market"))
+                    MarketFile = await _statusProvider.FindMarketFile(JournalDirectory);
 
-                if (!DisabledSupportFiles.Contains("Outfitting")) OutfittingFile = await _statusProvider.FindOutfittingFile(JournalDirectory);
+                if (!DisabledSupportFiles.Contains("Outfitting"))
+                    OutfittingFile = await _statusProvider.FindOutfittingFile(JournalDirectory);
 
-                if (!DisabledSupportFiles.Contains("Shipyard")) ShipyardFile = await _statusProvider.FindShipyardFile(JournalDirectory);
+                if (!DisabledSupportFiles.Contains("Shipyard"))
+                    ShipyardFile = await _statusProvider.FindShipyardFile(JournalDirectory);
 
-                if (!DisabledSupportFiles.Contains("NavRoute")) NavRouteFile = await _statusProvider.FindNavRouteFile(JournalDirectory);
-                
-                if (!DisabledSupportFiles.Contains("Backpack")) BackpackFile = await _statusProvider.FindBackpackFile(JournalDirectory);
+                if (!DisabledSupportFiles.Contains("NavRoute"))
+                    NavRouteFile = await _statusProvider.FindNavRouteFile(JournalDirectory);
 
-                if (!DisabledSupportFiles.Contains("ModulesInfo")) ModulesInfoFile = await _statusProvider.FindModulesFile(JournalDirectory);
+                if (!DisabledSupportFiles.Contains("Backpack"))
+                    BackpackFile = await _statusProvider.FindBackpackFile(JournalDirectory);
+
+                if (!DisabledSupportFiles.Contains("ModulesInfo"))
+                    ModulesInfoFile = await _statusProvider.FindModulesFile(JournalDirectory);
 
                 if (!DisabledSupportFiles.Contains("Bindings"))
                 {
@@ -459,36 +485,38 @@ namespace EliteAPI
                 }
             }
 
-            catch (Exception ex) { _log.LogWarning(ex, "Could not set support files"); }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "Could not set support files");
+            }
         }
-        
+
         private Task CheckComputerOperatingSystem()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) _log.LogWarning("You are not running on a Windows machine, some features may not work properly");
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                _log.LogWarning("You are not running on a Windows machine, some features may not work properly");
 
             return Task.CompletedTask;
         }
 
-        private async Task ProcessHistoricalJournalFiles(int? daysToProcess)
+        private async Task ProcessHistoricalJournalFiles(TimeSpan spanToProcess)
         {
             try
             {
                 var journalFiles = await _journalProvider.FindJournalFiles(JournalDirectory);
 
-                if (daysToProcess != null)
-                {
-                    var limitDateTime = DateTime.Now.AddDays(-daysToProcess.Value);
+                var limitDateTime = DateTime.Now - spanToProcess;
 
-                    journalFiles = journalFiles
-                        .Skip(1)
-                        .Where(f => f.LastWriteTime >= limitDateTime)
-                        .OrderBy(f => f.LastWriteTime)
-                        .ToArray();
-                }
+                journalFiles = journalFiles
+                    .Skip(1)
+                    .Where(f => f.LastWriteTime >= limitDateTime)
+                    .OrderBy(f => f.LastWriteTime)
+                    .ToArray();
+
 
                 foreach (var file in journalFiles)
                 {
-                    _log.LogInformation($"Processing file {file}");
+                    _log.LogInformation("Processing historic file {File}", file.Name);
 
                     await _journalProcessor.ProcessJournalFile(file, false);
                 }
@@ -496,7 +524,6 @@ namespace EliteAPI
             catch (Exception ex)
             {
                 _log.LogWarning(ex, "Could not process historical journal files");
-
                 throw;
             }
         }

--- a/EliteAPI/Journal/Provider/Abstractions/IJournalProvider.cs
+++ b/EliteAPI/Journal/Provider/Abstractions/IJournalProvider.cs
@@ -13,5 +13,11 @@ namespace EliteAPI.Journal.Provider.Abstractions
         /// </summary>
         /// <param name="journalDirectory"> The journal directory </param>
         Task<FileInfo> FindJournalFile(DirectoryInfo journalDirectory);
+
+        /// <summary>
+        /// Finds the journal files from the specified journal directory
+        /// </summary>
+        /// <param name="journalDirectory"> The journal directory </param>
+        Task<FileInfo[]> FindJournalFiles(DirectoryInfo journalDirectory);
     }
 }


### PR DESCRIPTION
Add support for processing historical journal files. Optional parameter to control the number of days in the past to process. 
Allows in-memory processing of events when the events occurred in a different journal. For example, processing the last 7 days of wing massacre missions.

Opt-in to the new feature via the configuration builder.

Example usage:
`service.AddEliteAPI(config =>
                    {
                        config.UseHistoricalJournals(7);
                        config.AddEventModule<CombatModule>();
                    });`

Let me know if you would like more detail in this PR.